### PR TITLE
Fix home page scroll overflow

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -95,6 +95,7 @@
             transform: translateY(-10px);
             visibility: hidden;
             transition: all 0.3s ease;
+            z-index: 50;
         }
 
         .profile-trigger:hover .profile-dropdown {
@@ -107,9 +108,9 @@
 <body class="min-h-screen bg-gradient overflow-hidden">
     <div id="particles-js"></div>
     
-    <div class="content-wrapper min-h-screen">
+    <div class="content-wrapper min-h-screen overflow-x-hidden overflow-y-auto">
         <!-- Header -->
-        <header class="glass-card p-4">
+        <header class="relative z-20 glass-card p-4">
             <div class="container mx-auto">
                 <div class="flex items-center justify-between">
                     <!-- Logo -->


### PR DESCRIPTION
## Summary
- allow scrolling inside the main content wrapper instead of the page body

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e01ec680483319bc50f6c76a0a408