### PR TITLE
Fix routing for module pages

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -75,18 +75,49 @@ def create_app():
     def home():
         if 'user_id' not in session:
             return redirect(url_for('index'))
-        
+
         # Buscar informações do usuário incluindo créditos
         # User já foi importado no topo do arquivo
         user = User.query.get(session['user_id'])
         balance_info = user.get_credit_balance() if user else {'balance': 0, 'formatted': '0.00'}
-        
+
         return render_template(
             "home.html",
             user_id=session.get('user_id'),
             username=session.get('username'),
             user_credits=balance_info
         )
+
+    def render_page(template_name):
+        """Renderiza páginas protegidas por sessão com informações do usuário."""
+        if 'user_id' not in session:
+            return redirect(url_for('index'))
+
+        user = User.query.get(session['user_id'])
+        balance_info = user.get_credit_balance() if user else {'balance': 0, 'formatted': '0.00'}
+
+        return render_template(
+            template_name,
+            user_id=session.get('user_id'),
+            username=session.get('username'),
+            user_credits=balance_info
+        )
+
+    @app.route("/cnh_form")
+    def cnh_form():
+        return render_page("cnh_form.html")
+
+    @app.route("/saved_cnhs")
+    def saved_cnhs():
+        return render_page("saved_cnhs.html")
+
+    @app.route("/credits")
+    def credits():
+        return render_page("credits.html")
+
+    @app.route("/profile")
+    def profile():
+        return render_page("profile.html")
 
     return app
     


### PR DESCRIPTION
## Summary
- add helper to render templates with user session info
- expose routes for CNH form, saved CNHs, credits, and profile pages

## Testing
- `python -m py_compile __init__.py run.py controllers/auth.py controllers/credits.py controllers/cnh.py controllers/pix_payment.py models/user.py models/credit_transaction.py models/cnh_request.py`
- `python - <<'PY'
from __init__ import app
client = app.test_client()
for path in ['/cnh_form','/saved_cnhs','/credits','/profile']:
    r = client.get(path)
    print(path, r.status_code, r.headers.get('Location'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a0eec398c88331b66398a71f6050e6