### PR TITLE
Fix dynamic section rendering for module routes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -75,18 +75,49 @@ def create_app():
     def home():
         if 'user_id' not in session:
             return redirect(url_for('index'))
-        
+
         # Buscar informações do usuário incluindo créditos
         # User já foi importado no topo do arquivo
         user = User.query.get(session['user_id'])
         balance_info = user.get_credit_balance() if user else {'balance': 0, 'formatted': '0.00'}
-        
+
         return render_template(
             "home.html",
             user_id=session.get('user_id'),
             username=session.get('username'),
             user_credits=balance_info
         )
+
+    def render_page(template_name):
+        """Renderiza páginas protegidas por sessão com informações do usuário."""
+        if 'user_id' not in session:
+            return redirect(url_for('index'))
+
+        user = User.query.get(session['user_id'])
+        balance_info = user.get_credit_balance() if user else {'balance': 0, 'formatted': '0.00'}
+
+        return render_template(
+            template_name,
+            user_id=session.get('user_id'),
+            username=session.get('username'),
+            user_credits=balance_info
+        )
+
+    @app.route("/cnh_form")
+    def cnh_form():
+        return render_page("cnh_form.html")
+
+    @app.route("/saved_cnhs")
+    def saved_cnhs():
+        return render_page("saved_cnhs.html")
+
+    @app.route("/credits")
+    def credits():
+        return render_page("credits.html")
+
+    @app.route("/profile")
+    def profile():
+        return render_page("profile.html")
 
     return app
     

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1439,22 +1439,43 @@
         // Initialize when page loads
         document.addEventListener('DOMContentLoaded', function() {
             console.log('🚀 Página carregada, inicializando...');
-            
+
             // Initialize dark mode
             initializeDarkMode();
-            
+
             // Start auto-refresh
             startAutoRefresh();
-            
-            // Show dashboard by default
-            showDashboard();
-            
+
+            // Determine current path and show appropriate section
+            const path = window.location.pathname;
+            const routeHandlers = {
+                '/home': () => showDashboard(),
+                '/cnh_form': () =>
+                    showSection('cnhSection', 'Gerar CNH', document.querySelector('a.sidebar-item[href="/cnh_form"]')),
+                '/saved_cnhs': () => {
+                    showSection('myCNHsSection', 'CNHs Salvas', document.querySelector('a.sidebar-item[href="/saved_cnhs"]'));
+                    loadMyCNHs(1);
+                },
+                '/credits': () => {
+                    showSection('creditsSection', 'Créditos', document.querySelector('a.sidebar-item[href="/credits"]'));
+                    loadTransactionHistory();
+                },
+                '/profile': () =>
+                    showSection('profileSection', 'Perfil', document.querySelector('a.sidebar-item[href="/profile"]')),
+            };
+
+            if (routeHandlers[path]) {
+                routeHandlers[path]();
+            } else if (document.getElementById('dashboardSection')) {
+                showDashboard();
+            }
+
             // Sidebar toggle for mobile
             const sidebarToggle = document.getElementById('sidebarToggle');
             if (sidebarToggle) {
                 sidebarToggle.addEventListener('click', toggleSidebar);
             }
-            
+
             // CPF input formatting
             const cpfInput = document.getElementById('cpf');
             if (cpfInput) {


### PR DESCRIPTION
## Summary
- show correct dashboard, CNH, saved CNH, credits or profile sections based on current URL
- highlight active sidebar link and trigger necessary data loads

## Testing
- `python -m py_compile __init__.py run.py controllers/auth.py controllers/credits.py controllers/cnh.py controllers/pix_payment.py models/user.py models/credit_transaction.py models/cnh_request.py`
- `python - <<'PY'
from __init__ import app
client = app.test_client()
with client.session_transaction() as sess:
    sess['user_id'] = 1
    sess['username'] = 'test'
paths = [('/cnh_form','id="cnhForm"'),('/saved_cnhs','id="myCNHsSection"'),('/credits','id="creditsSection"'),('/profile','id="profileSection"')]
for path, marker in paths:
    r = client.get(path)
    text = r.get_data(as_text=True)
    print(path, r.status_code, marker in text)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a0eec398c88331b66398a71f6050e6